### PR TITLE
Pin verji-onboarding-module to 0.3.2 (re-invite-after-leave hotfix)

### DIFF
--- a/build_config.verji.yaml
+++ b/build_config.verji.yaml
@@ -30,7 +30,7 @@ skip_module_dependency_version_check: true
 modules:
     - "@verji/verji-cryptosetup-module"
     - "@verji/verji-usermenu-module"
-    - "@verji/verji-onboarding-module"
+    - "@verji/verji-onboarding-module@0.3.2"
     - "@verji/verji-usersearch-module"
     - "@verji/verji-news-module"
     - "@verji/verji-eventsearch-module"


### PR DESCRIPTION
Pins `@verji/verji-onboarding-module` to **0.3.2** in `build_config.verji.yaml`.

### Why
The build installs modules via `yarn add` with no version, so it resolves the `latest` dist-tag — currently **0.3.1**, the version carrying the *re-invite after leave* bug (a user who left a room could not be re-invited because the "already in room" filter used `room.getMembers()`, which includes `leave` members). Every unpinned build since — including verji-develop-189/190 and the latest #195 — shipped 0.3.1.

### Effect
- Installs **0.3.2** (0.3.1 + the fix, [onboarding-module PR #11](https://github.com/verji/verji-onboarding-module/pull/11)) by **exact version**, so it's independent of dist-tags.
- Does **not** move `latest` (stays 0.3.1) or touch the `verji-v2` channel (2.0.1) — zero blast radius on other consumers.

### Verify after deploy
Create a room → invite a user → have them leave → re-invite: the user now appears. Sanity-check a normal invite and a new-room invite still work.

Diff is a single line (`@0.3.2` pin).